### PR TITLE
error handling in serverStream

### DIFF
--- a/projects/core/src/lib/grpc-client.ts
+++ b/projects/core/src/lib/grpc-client.ts
@@ -65,6 +65,7 @@ export class GrpcClient {
       xhrStream.on('status', status => obs.next(status));
       xhrStream.on('data', response => obs.next(response));
       xhrStream.on('end', () => obs.complete());
+      xhrStream.on('error', error => obs.error(error));
 
       return () => xhrStream.cancel();
     });


### PR DESCRIPTION
Pass errors from `serverStream()` to application's observable.